### PR TITLE
add the mandatory kid parameter to ProtectedHeader

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,12 @@ func main() {
 			}
 		}
 
-		out, err = sign(out, meta, *contentType, signer)
+		kid, err := getKidFromJWK(keyData)
+		if err != nil {
+			log.Fatalf("error: %v", err)
+		}
+
+		out, err = sign(out, meta, *contentType, kid, signer)
 	}
 
 	if outPath == "-" || *writeToStdout {


### PR DESCRIPTION
We'll need to tag a new release after this so that veraison/corim can use the new gen-testcase